### PR TITLE
fix conf thres for confusion_matrix

### DIFF
--- a/train.py
+++ b/train.py
@@ -440,7 +440,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                                             verbose=True,
                                             plots=True,
                                             callbacks=callbacks,
-                                            compute_loss=compute_loss)  # val best model with plots
+                                            compute_loss=compute_loss,
+                                            conf_mat_thres = 0.25)  # val best model with plots
                     if is_coco:
                         callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
 


### PR DESCRIPTION
when doing a train the confusion matrix generated at the end of the train is generated with a confidence threshold of 0.25